### PR TITLE
Add Kafka file sink console application

### DIFF
--- a/KafkaFileSink.csproj
+++ b/KafkaFileSink.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/MessageHandler.cs
+++ b/MessageHandler.cs
@@ -1,0 +1,12 @@
+public interface IMessageHandler
+{
+    bool ShouldProcess(string message);
+}
+
+public class MessageHandler : IMessageHandler
+{
+    public bool ShouldProcess(string message)
+    {
+        return !string.IsNullOrWhiteSpace(message);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using Confluent.Kafka;
+using Microsoft.Extensions.Configuration;
+
+var configuration = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+    .Build();
+
+var kafkaConfig = new ConsumerConfig
+{
+    BootstrapServers = configuration["Kafka:BootstrapServers"],
+    GroupId = configuration["Kafka:GroupId"],
+    AutoOffsetReset = AutoOffsetReset.Earliest
+};
+
+var topic = configuration["Kafka:Topic"] ?? throw new InvalidOperationException("Topic not configured");
+var outputFile = configuration["Output:FilePath"] ?? "output.txt";
+
+Directory.CreateDirectory(Path.GetDirectoryName(outputFile) ?? string.Empty);
+
+IMessageHandler handler = new MessageHandler();
+
+using var consumer = new ConsumerBuilder<string, string>(kafkaConfig).Build();
+consumer.Subscribe(topic);
+
+var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    cts.Cancel();
+};
+
+Console.WriteLine("Listening for messages. Press Ctrl+C to exit.");
+
+try
+{
+    while (!cts.IsCancellationRequested)
+    {
+        var result = consumer.Consume(cts.Token);
+        if (handler.ShouldProcess(result.Message.Value))
+        {
+            File.AppendAllText(outputFile, result.Message.Value + Environment.NewLine);
+            Console.WriteLine($"Processed message: {result.Message.Value}");
+        }
+        else
+        {
+            Console.WriteLine("Ignored message");
+        }
+    }
+}
+catch (OperationCanceledException)
+{
+    // graceful shutdown
+}
+finally
+{
+    consumer.Close();
+}

--- a/Program.cs
+++ b/Program.cs
@@ -44,7 +44,17 @@ try
         var result = consumer.Consume(cts.Token);
         if (handler.ShouldProcess(result.Message.Value))
         {
-            File.AppendAllText(outputFile, result.Message.Value + Environment.NewLine);
+StreamWriter? writer = null;
+try
+{
+    writer = new StreamWriter(outputFile, append: true);
+    while (!cts.IsCancellationRequested)
+    {
+        var result = consumer.Consume(cts.Token);
+        if (handler.ShouldProcess(result.Message.Value))
+        {
+            writer.WriteLine(result.Message.Value);
+            writer.Flush();
             Console.WriteLine($"Processed message: {result.Message.Value}");
         }
         else

--- a/Program.cs
+++ b/Program.cs
@@ -17,7 +17,11 @@ var kafkaConfig = new ConsumerConfig
 var topic = configuration["Kafka:Topic"] ?? throw new InvalidOperationException("Topic not configured");
 var outputFile = configuration["Output:FilePath"] ?? "output.txt";
 
-Directory.CreateDirectory(Path.GetDirectoryName(outputFile) ?? string.Empty);
+var outputDir = Path.GetDirectoryName(outputFile);
+if (!string.IsNullOrEmpty(outputDir))
+{
+    Directory.CreateDirectory(outputDir);
+}
 
 IMessageHandler handler = new MessageHandler();
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Kafka-File-Sink
+# Kafka File Sink
+
+This repository contains a simple .NET console application that consumes messages from a Kafka topic and writes selected messages to a file.
+
+## Configuration
+
+All settings are stored in `appsettings.json`.
+
+- `Kafka:BootstrapServers` – Kafka broker list
+- `Kafka:Topic` – topic to subscribe to
+- `Kafka:GroupId` – consumer group id
+- `Output:FilePath` – path to the output file where accepted messages are appended
+
+## Build and Run
+
+Ensure the .NET SDK is installed.
+
+```bash
+dotnet build
+dotnet run
+```

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Kafka": {
+    "BootstrapServers": "localhost:9092",
+    "Topic": "my-topic",
+    "GroupId": "file-sink-group"
+  },
+  "Output": {
+    "FilePath": "output/messages.txt"
+  }
+}


### PR DESCRIPTION
## Summary
- add .NET console app that consumes Kafka messages
- forward messages through a handler to decide whether to write to file
- configure Kafka connection and output file path via appsettings

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a1a2169c83259f1156c2aa2c87ea